### PR TITLE
Fixed the inadvertent fallthrough to HRs

### DIFF
--- a/src/Consts.bi
+++ b/src/Consts.bi
@@ -1,0 +1,228 @@
+Const SS_B_Bats = 0 '-1=Left, 0=Switch, 1=Right'
+
+Const SS_B_G = 3
+Const SS_B_AB = 4
+Const SS_B_R = 5
+Const SS_B_H = 6
+Const SS_B_2B = 7
+Const SS_B_3B = 8
+Const SS_B_HR = 9
+Const SS_B_RBI = 10
+Const SS_B_W = 11
+Const SS_B_K = 12
+Const SS_B_SB = 13
+Const SS_B_CS = 14
+Const SS_B_Arm = 15
+Const SS_B_Run = 16
+Const SS_B_Range = 17
+Const SS_B_GndPct = 18
+Const SS_B_FldPct = 19
+Const SS_B_LgBAvg = 20
+Const SS_B_Avail = 21   ' 99-Available, 0=In Game?, 1=Injured, 2=Resting, 3=Suspended, 4=Inactive, 1=Removed from game?
+Const SS_B_Pos1 = 22
+Const SS_B_Pos2 = 23
+Const SS_B_Pos3 = 24
+Const SS_B_Pos4 = 25
+Const SS_B_FldPct1 = 26
+Const SS_B_FldPct2 = 27
+Const SS_B_FldPct3 = 28
+Const SS_B_FldPct4 = 29
+Const SS_B_Bunt = 30
+Const SS_B_Active = 31  ' 0=Active, 1=Inactive
+'32 is INJURY?'
+
+Const SS_B_Arm1   = 33
+Const SS_B_Range1 = 34
+Const SS_B_Arm2   = 35
+Const SS_B_Range2 = 36
+Const SS_B_Arm3   = 37
+Const SS_B_Range3 = 38
+Const SS_B_Arm4   = 39
+Const SS_B_Range4 = 40
+
+' 41-79 could be SPLITS - at least 41-55 are '
+Const SS_B_LHP_AB = 42
+Const SS_B_LHP_H = 43
+'44 is unknown'
+'45 is unknown'
+'46 is unknown'
+'47 is unknown'
+'48 is unknown'
+Const SS_B_RHP_AB = 49
+Const SS_B_RHP_H = 50
+'51 is unknown'
+'52 is unknown'
+'53 is unknown'
+'54 is unknown'
+'55 is unknown'
+
+'80 is unknown'
+
+Const SS_P_Throws = 0
+Const SS_P_W = 1
+Const SS_P_L = 2
+Const SS_P_Sv = 3
+Const SS_P_G = 4
+Const SS_P_GS = 5
+Const SS_P_IP = 6
+Const SS_P_H = 7
+Const SS_P_BB =  8
+Const SS_P_K = 9
+Const SS_P_ERA100 = 10 'ERA*100
+Const SS_P_BAvg = 11
+Const SS_P_GndPct = 12
+Const SS_P_HR = 13
+Const SS_P_LgBAvg = 14
+Const SS_P_Avail = 15
+Const SS_P_CG = 16
+Const SS_P_FldPct = 17
+Const SS_P_HoldRunner = 18
+
+Const SS_P_H_G  = 19
+Const SS_P_H_AB = 20
+Const SS_P_H_R  = 21
+Const SS_P_H_H  = 22
+Const SS_P_H_2B = 23
+Const SS_P_H_3B = 24
+Const SS_P_H_HR = 25
+Const SS_P_H_RBI= 26
+Const SS_P_H_BB = 27
+Const SS_P_H_SO = 28
+Const SS_P_H_SB = 29
+Const SS_P_H_CS = 30
+Const SS_P_Range= 31
+Const SS_P_Bunt = 32
+Const SS_P_SH   = 33
+
+Const SS_P_Rest = 35
+
+' 37-88 could be SPLITS'
+
+Const SS_P_LHP_AB = 51
+Const SS_P_LHP_H = 52
+
+Const SS_P_RHP_AB = 58
+Const SS_P_RHP_H = 59
+
+
+Const LG_B_AB  = 0
+Const LG_B_H   = 1
+Const LG_B_R   = 2
+Const LG_B_RBI = 3
+Const LG_B_Dbl = 4
+Const LG_B_Trp = 5
+Const LG_B_HR  = 6
+Const LG_B_W   = 7
+Const LG_B_K   = 8
+Const LG_B_SB  = 9
+Const LG_B_CS  = 10
+Const LG_B_E   = 11
+Const LG_B_HS  = 12
+Const LG_B_LS  = 13
+Const LG_B_G   = 14
+Const LG_B_PO  = 16
+Const LG_B_A   = 17
+
+Const LG_P_IP3  = 0
+Const LG_P_H    = 1
+Const LG_P_R    = 2
+Const LG_P_ER   = 3
+Const LG_P_BB   = 4
+Const LG_P_K    = 5
+Const LG_P_W    = 6
+Const LG_P_L    = 7
+Const LG_P_G    = 8
+Const LG_P_GS   = 9
+Const LG_P_CG   = 10
+Const LG_P_Sv   = 12
+Const LG_P_HR   = 14
+Const LG_P_RInh = 17
+Const LG_P_BSv  = 19
+Const LG_P_Hold = 22
+
+Const LG_P_E    = 34 '???'
+
+Const LIVE_BAvg=0
+Const LIVE_2B = 1
+Const LIVE_3B = 2
+Const LIVE_HR = 3
+Const LIVE_K  = 4
+Const LIVE_BB = 5
+Const LIVE_L_HR=6
+Const LIVE_R_HR=7
+
+
+Const TM_BAVG   = 1
+Const TM_K      = 2
+Const TM_BB     = 3
+Const TM_HR     = 4
+Const TM_XX     = 5
+Const TM_2B     = 6
+Const TM_3B     = 7
+Const TM_FOUL   = 8
+Const TM_OUTDOORS= 9
+Const TM_GRASS  = 10
+Const TM_FG     = 11
+Const TM_BG     = 12
+Const TM_PARK_ID= 13
+
+Const BASE_EMPTY= 0
+Const BASE_1    = 1
+Const BASE_2    = 2
+Const BASE_3    = 3
+Const BASE_1_2  = 4
+Const BASE_1_3  = 5
+Const BASE_2_3  = 6
+Const BASE_FULL = 7
+
+Const INF_NORMAL = 0
+Const INF_CORNERS_IN = 1
+Const INF_INFIELD_IN = 2
+Const INF_GUARD_LINES = 3
+' Const INF_SHIFT = 4
+' Const INF_PULL = 5
+
+Const POS_P  = 1
+Const POS_C  = 2
+Const POS_1B = 3
+Const POS_2B = 4
+Const POS_3B = 5
+Const POS_SS = 6
+Const POS_LF = 7
+Const POS_CF = 8
+Const POS_RF = 9
+Const POS_DH = 0
+
+Const MGR_CLOSE_STRATEGY     = 581
+Const MGR_INN_SAVE_OPP       = 582
+Const MGR_INN_AHEAD          = 583
+Const MGR_INN_TIED_AHEAD     = 584
+Const MGR_TIRED_AHEAD        = 585
+Const MGR_TIRED_TIED_AHEAD   = 586
+Const MGR_SAVE_OPP_OCCURS    = 587
+Const MGR_INN_CLOSE_STRATEGY = 588
+Const MGR_USE_BOTH_SETUP_CLOSER = 589
+
+Const EVENT_HPB   = 1
+Const EVENT_BB_OR_INTERFERENCE= 2
+Const EVENT_BALK  =  4
+Const EVENT_PB    =  5
+Const EVENT_WP    =  6
+Const EVENT_1B    =  7
+Const EVENT_2B    =  8
+Const EVENT_3B    =  9
+Const EVENT_HR    = 10
+Const EVENT_PSBL_SINGLE = 12
+Const EVENT_DP          = 15
+Const EVENT_STEAL       = 16
+Const EVENT_FLY_DEEP    = 17
+Const EVENT_FLY_REGULAR = 18
+Const EVENT_FLY_SHALLOW = 19
+Const EVENT_INF_POPUP   = 20
+Const EVENT_RUNNER_DBLD = 21
+Const EVENT_RUNDOWN     = 22
+Const EVENT_BUNT        = 23
+
+Const PLAY_MODE_HUMAN    = 0
+Const PLAY_MODE_COMPUTER = 1
+Const PLAY_MODE_PCvsPC   = 2

--- a/src/GameRoutines.bi
+++ b/src/GameRoutines.bi
@@ -1,3 +1,5 @@
+'$INCLUDE: 'Consts.bi'
+
 Declare Sub LOADER
 Declare Sub StartingLineup (P9)
 Declare Sub LineupPositions (teamIdx, posIdx)

--- a/src/HELLO.BAS
+++ b/src/HELLO.BAS
@@ -1108,7 +1108,7 @@ Sub LOADER
             'Locate 23, 2: Color 14
             'Print "NOTE:: "
             'Color 15
-            
+
             'Locate , 2: Print "* NOTE ABOUT RULES GOES HERE"
 
             Do
@@ -2994,7 +2994,7 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
                     BP(9) = 1
                     Exit For
                 Else
-                    
+
                     J = J - 1
                     currPos = 0
 
@@ -5933,6 +5933,7 @@ Sub SOURCE ()
 
     '----- NOODLE -----
 
+    GoTo 13684
 
     13530 '
     ' *** HOME RUN S2%=10 ***
@@ -11026,7 +11027,7 @@ Sub GETOUTFIELDER (currFielder, P, I1, D)
     Call GETFIELDER(currFielder, P, I1, D)
 
     Call Rolld100(RN0)
-    
+
     If RN0 <= 30 Then
         currFielder = 8
     Else
@@ -11832,7 +11833,7 @@ Sub PICKEDOFF (D, i)
     Call DELIVERY(D)
 
     Call Rolld100(RN)
-    
+
     Select Case RN
         Case 1 To 33: pbpString$ = "NO, " + pitchers$(D, P1(D)) + " throws to " + baseName$(i - 1)
         Case 34 To 66: pbpString$ = "quick move to " + baseName$(i - 1)
@@ -13084,7 +13085,7 @@ Sub RecordRun (sah%, i, D, F%, PQ, S2%, currFielder, INFPOS%)
             A5%(2) = 0
             A5%(3) = 0
         End If
-        
+
 
     End If
 
@@ -17920,18 +17921,18 @@ Sub COMPILESTATFILES (teamIdx)
         Print #1, batters$(teamIdx, I)
         Print #1, gameB(teamIdx, I)
     Next I
-    
+
     For I = 0 To 21:
         Print #1, pitchers$(teamIdx, I)
         Print #1, gameP(teamIdx, I)
     Next I
-    
+
     For I = 0 To 22:
         For I1 = 0 To 21:
             Print #1, statB0(I, I1)
         Next I1
     Next I
-    
+
     For I = 0 To 21:
         For I1 = 0 To 41:
             Print #1, statP0(I, I1)
@@ -17944,7 +17945,7 @@ Sub COMPILESTATFILES (teamIdx)
     For I = 0 To 21:
         Print #1, statT0!(I)
     Next I
-    
+
     For I = 0 To 22:
         Print #1, statT1!(I)
     Next I
@@ -18014,7 +18015,7 @@ Sub COMPILESTATFILES (teamIdx)
     Else
         locIndicator$(numberGames) = "H"
     End If
-    
+
     teamScore(numberGames) = gameScore(teamIdx, 0)
     oppName$(numberGames) = gameTeams$(1 - teamIdx)
     oppScore(numberGames) = gameScore(1 - teamIdx, 0)
@@ -18392,7 +18393,7 @@ Sub BOX2FILE (printChoice, boxName$)
                     If gamePitStats(I, I2, 0) - (Int(gamePitStats(I, I2, 0) / 3) * 3) > 0 Then
                         Print #2, ".";: Print #2, Using "#"; gamePitStats(I, I2, 0) - (Int(gamePitStats(I, I2, 0) / 3) * 3);
                     End If
-                    
+
                     Print #2, Tab(34);
                     Print #2, Using "## ##  ## ## ##"; gamePitStats(I, I2, 1); gamePitStats(I, I2, 2); gamePitStats(I, I2, 3); gamePitStats(I, I2, 4); gamePitStats(I, I2, 5);
                     Print #2, "   ";
@@ -19755,13 +19756,13 @@ Sub ReadGameTeam (teamYear$, targetTeam$, teamIdx, gameIdx, dataOK)
                 pitchRating(gameIdx, X, X1 + 36) = 0
             Next
         Next
-        
+
         dataOK = 1
-        
+
     Else
-    
+
         dataOK = 0
-        
+
     End If
 
 End Sub

--- a/src/HELLO.BAS
+++ b/src/HELLO.BAS
@@ -2953,7 +2953,7 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
     For I = 0 To 22
         'Essentially a form of setting the player as inactive
         If batters$(P9, I) = "XXX" Then
-            batRating(P9, I, 21) = 98
+            batRating(P9, I, SS_B_Avail) = 98
         End If
     Next
 
@@ -2984,7 +2984,7 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
                 position(I2, 1) = -1
             Next
 
-            I2 = 0
+            currPos = 0
 
             'Final Position
             If I = 1 Then
@@ -2994,35 +2994,32 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
                     BP(9) = 1
                     Exit For
                 Else
-
                     J = J - 1
                     currPos = 0
 
                     For batterIdx = 0 To 22
 
-                        If batRating(P9, batterIdx, 21) <= 0 And batters$(P9, batterIdx) <> "XXX" Then
+                        If batRating(P9, batterIdx, SS_B_Avail) <= 0 And batters$(P9, batterIdx) <> "XXX" Then
 
-                            'Assign position based on % of At Bats
-                            If batRating(P9, batterIdx, 22) = 0 Then
-                                'Position 1 from Batter Input
-                                position(currPos, 0) = batRating(P9, batterIdx, 4)
-                            Else
-                                If batRating(P9, batterIdx, 23) = 0 Then
-                                    'Position 2 from Batter Input
-                                    position(currPos, 0) = batRating(P9, batterIdx, 4) * .5
+                            If     batRating(P9, batterIdx, SS_B_Pos1) = 0 Then
+                                If     batRating(P9, batterIdx, SS_B_Pos2) = -1 Then
+                                    position(currPos, 0) = batRating(P9, batterIdx, SS_B_AB)
+                                ElseIf batRating(P9, batterIdx, SS_B_Pos3) = -1 Then
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .9 + .5)
+                                ElseIf batRating(P9, batterIdx, SS_B_Pos4) = -1 Then
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .8 + .5)
                                 Else
-                                    'Position 3 from Batter Input
-                                    If batRating(P9, batterIdx, 24) = 0 Then
-                                        position(currPos, 0) = batRating(P9, batterIdx, 4) * .3
-                                    Else
-                                        'Position 4 from Batter Input
-                                        If batRating(P9, batterIdx, 25) = 0 Then
-                                            position(currPos, 0) = batRating(P9, batterIdx, 4) * .2
-                                        Else
-                                            position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .05)
-                                        End If
-                                    End If
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .7 + .5)
                                 End If
+
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos2) = 0 Then
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .5  + .5)
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos3) = 0 Then
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .3  + .5)
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos4) = 0 Then
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .2  + .5)
+                                        Else
+                                    position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .05 + .5)    ' no DH experience
                             End If
 
                             position(currPos, 1) = batterIdx
@@ -3033,56 +3030,51 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
                     Next batterIdx
 
                 End If
-
             Else
+
+                'I <> 1
+                ' For each fielding position I (1-9), for each active player who plays that position, and store his
+                ' "normalized" at-bats in position(currPos, 0) and the field position # in position(currPos, 1)
 
                 'Most positions
                 For batterIdx = 0 To 22:
+                    If batRating(P9, batterIdx, SS_B_Avail) <= 0 And batters$(P9, batterIdx) <> "XXX" Then
 
-                    If batRating(P9, batterIdx, 21) <= 0 And batters$(P9, batterIdx) <> "XXX" Then
-                        If batRating(P9, batterIdx, 22) = I And batRating(P9, batterIdx, 23) = -1 Then
-                            position(currPos, 0) = batRating(P9, batterIdx, 4):
-                        Else
-                            If batRating(P9, batterIdx, 22) = I And batRating(P9, batterIdx, 24) = -1 Then
-                                position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .9)
-                            Else
-                                If batRating(P9, batterIdx, 22) = I And batRating(P9, batterIdx, 25) = -1 Then
-                                    position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .8)
+                        If batRating(P9, batterIdx, SS_B_Pos1) = I Then
+                            If     batRating(P9, batterIdx, SS_B_Pos2) = -1 Then
+                                position(currPos, 0) = batRating(P9, batterIdx, SS_B_AB)
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos3) = -1 Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .9 + .5)
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos4) = -1 Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .8 + .5)
                                 Else
-                                    If batRating(P9, batterIdx, 22) = I Then
-                                        position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .7)
-                                    Else
-                                        If batRating(P9, batterIdx, 23) = I And batRating(P9, batterIdx, 24) = -1 Then
-                                            position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                        Else
-                                            If batRating(P9, batterIdx, 23) = I And batRating(P9, batterIdx, 25) = -1 Then
-                                                position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                            Else
-                                                If batRating(P9, batterIdx, 23) = I Then
-                                                    position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                                Else
-                                                    If batRating(P9, batterIdx, 24) = I And batRating(P9, batterIdx, 25) = -1 Then
-                                                        position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                                    Else
-                                                        If batRating(P9, batterIdx, 24) = I Then
-                                                            position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                                        Else
-                                                            If batRating(P9, batterIdx, 25) = I Then
-                                                                position(currPos, 0) = CInt(batRating(P9, batterIdx, 4) * .1)
-                                                            End If
-                                                        End If
-                                                    End If
-                                                End If
-                                            End If
-                                        End If
-                                    End If
-                                End If
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .7 + .5)
                             End If
-                        End If
+
+                        ElseIf batRating(P9, batterIdx, SS_B_Pos2) = I Then
+                            If     batRating(P9, batterIdx, SS_B_Pos3) = -1 Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
+                            ElseIf batRating(P9, batterIdx, SS_B_Pos4) = -1 Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
+                                            Else
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
+                            End If
+
+                        ElseIf batRating(P9, batterIdx, SS_B_Pos3) = I Then
+                            If     batRating(P9, batterIdx, SS_B_Pos4) = -1 Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
+                                                        Else
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
+                                                            End If
+
+                        ElseIf batRating(P9, batterIdx, SS_B_Pos4) = I Then
+                                position(currPos, 0) = Int(batRating(P9, batterIdx, SS_B_AB) * .1 + .5)
                     End If
 
                     position(currPos, 1) = batterIdx
                     currPos = currPos + 1
+
+                    End If
 
                 Next batterIdx
 
@@ -3093,24 +3085,32 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
 
             For I1 = 0 To currPos
                 AB% = AB% + position(I1, 0)
+
             Next
 
             RN = Int(Rnd(1) * AB%) + 1
 
-            For I1 = 0 To I2
+            ' For each fielding position I (1-9), find a position(I1, 0) [i.e., at-bats] value that is above the random threshold, and
+            ' assign the player to that position
+
+            lineupDone% = 0
+
+            For I1 = 0 To currPos
 
                 If RN <= position(I1, 0) Then
                     batLUIdx(J) = position(I1, 1)
-                    batRating(P9, position(I1, 1), 21) = 1
+                    batRating(P9, position(I1, 1), SS_B_Avail) = 1
                     lineupDone% = 1
+
+                    Exit For
                 Else
                     position(I1 + 1, 0) = position(I1 + 1, 0) + position(I1, 0)
+
                 End If
 
             Next I1
 
             If lineupDone% <> 1 Then
-
                 Locate 25, 1: Print "CANNOT MAKE A LINEUP!!...";
                 noLineups = 1
                 'reselect = 1
@@ -3125,7 +3125,7 @@ Sub ComputerLineups (batterFlag%, P9, noLineups, reselect)
                 C1 = 0
 
                 For J = 0 To 22
-                    If batRating(P9, J, 21) <> 99 Then batRating(P9, J, 21) = 0
+                    If batRating(P9, J, SS_B_Avail) <> 99 Then batRating(P9, J, SS_B_Avail) = 0
                 Next
 
                 If autoPlay <> 1 Then
@@ -4528,7 +4528,7 @@ Sub SOURCE ()
 
     If I3 <= 350 Then 13050
 
-    If I9 <= (B4%(P, 4, B1!(P)) * 2 * .33) Then
+    If I9 <= (B4%(P, LIVE_K, B1!(P)) * 2 * .33) Then
 
         nbrStrikes = nbrStrikes + 1
         Call PBP(player$(0) + " swings and misses")
@@ -4547,7 +4547,7 @@ Sub SOURCE ()
         End If
     End If
 
-    If I9 <= B4%(P, 4, B1!(P)) * 2 Then
+    If I9 <= B4%(P, LIVE_K, B1!(P)) * 2 Then
         Call PBP(player$(0) + " fouls off the pitch...hit away")
         Call DELAY
         P2 = 1
@@ -4891,7 +4891,7 @@ Sub SOURCE ()
         GoTo 13900
     End If
 
-    If H6% <= B4%(P, 5, B1!(P)) + 25 Then
+    If H6% <= B4%(P, LIVE_BB, B1!(P)) + 25 Then
         S2% = 2
         '13240 / *** base on balls ***
         Call BASEONBALLS(S2%, D2, D, P)
@@ -4935,14 +4935,14 @@ Sub SOURCE ()
         GoTo 13063
     End If
 
-    If H6% > B4%(P, 0, B1!(P)) + I4 Then
+    If H6% > B4%(P, LIVE_BAvg, B1!(P)) + I4 Then
 
         '3600
         ' *** check for strikeout ***
         H6% = Int(Rnd(1) * 1000) + 1
-        strikeoutRating = B4%(P, 4, B1!(P))
+        strikeoutRating = B4%(P, LIVE_K, B1!(P))
 
-        If H6% > B4%(P, 4, B1!(P)) Then
+        If H6% > B4%(P, LIVE_K, B1!(P)) Then
 
             ' *** ground ball for out ***
             Call Rolld100(H6%)
@@ -5576,7 +5576,7 @@ Sub SOURCE ()
 
         H6% = Int(Rnd(1) * 1000) + 1
 
-        If H6% <= B4%(P, 1, B1!(P)) And P2 <> 2 Or H6% <= B4%(P, 1, B1!(P)) * .5 And P2 = 2 Then
+        If H6% <= B4%(P, LIVE_2B, B1!(P)) And P2 <> 2 Or H6% <= B4%(P, LIVE_2B, B1!(P)) * .5 And P2 = 2 Then
 
             S2% = 8
 
@@ -5732,7 +5732,7 @@ Sub SOURCE ()
         End If
 
 
-        If H6% <= B4%(P, 1, B1!(P)) + B4%(P, 2, B1!(P)) And P2 <> 2 Or H6% <= B4%(P, 1, B1!(P)) * .5 + B4%(P, 2, B1!(P)) * .5 And P2 = 2 Then
+        If H6% <= B4%(P, LIVE_2B, B1!(P)) + B4%(P, LIVE_3B, B1!(P)) And P2 <> 2 Or H6% <= B4%(P, LIVE_2B, B1!(P)) * .5 + B4%(P, LIVE_3B, B1!(P)) * .5 And P2 = 2 Then
 
             S2% = 9
 
@@ -5874,21 +5874,21 @@ Sub SOURCE ()
 
         Call HITS2GAP(currFielder, P, I1, D)
 
-        I3 = B4%(P, 1, B1!(P)) + B4%(P, 2, B1!(P))
+        I3 = B4%(P, LIVE_2B, B1!(P)) + B4%(P, LIVE_3B, B1!(P))
 
-        E2% = I3 + B4%(P, 3, B1!(P))
+        E2% = I3 + B4%(P, LIVE_HR, B1!(P))
         If currFielder = 8 And H6% <= E2% And P2 <> 2 Or currFielder = 8 And H6% <= E2% * .5 And P2 = 2 Then
             S2% = 10
             GoTo 13530
         End If
 
-        E2% = I3 + B4%(P, 6, B1!(P))
+        E2% = I3 + B4%(P, LIVE_L_HR, B1!(P))
         If currFielder = 7 And H6% <= E2% And P2 <> 2 Or currFielder = 7 And H6% <= E2% * .5 And P2 = 2 Then
             S2% = 10
             GoTo 13530
         End If
 
-        E2% = I3 + B4%(P, 7, B1!(P))
+        E2% = I3 + B4%(P, LIVE_R_HR, B1!(P))
         If currFielder = 9 And H6% <= E2% And P2 <> 2 Or currFielder = 9 And H6% <= E2% * .5 And P2 = 2 Then
             S2% = 10
             GoTo 13530
@@ -5898,7 +5898,8 @@ Sub SOURCE ()
         Call Rolld100(H6%)
         S2% = 7
 
-        If B7%(P, B1!(P)) = 1 Or H7% <= SN Then
+        ' If B7%(P, B1!(P)) = 1 Or H7% <= SN Then
+        If B7%(P, B1!(P)) <> 1 And H6% <= B4%(P, LIVE_BAvg, B1!(P)) And P2 <> 2 Then
 
             13065 '/ *** single ***
             Call SINGLEROUTINE(currFielder, P, I1, D, S2%, P2)
@@ -8313,14 +8314,14 @@ Sub SOURCE ()
             GoTo 15055
         End If
 
-        Ib4 = B4%(P, 0, B1!(P))
-        I1 = B4%(P, 3, B1!(P))
+        Ib4 = B4%(P, LIVE_BAvg, B1!(P))
+        I1 = B4%(P, LIVE_HR, B1!(P))
         If B1!(P) = 9 Then
-            I2 = B4%(P, 0, 0)
-            I3 = B4%(P, 3, 0)
+            I2 = B4%(P, LIVE_BAvg, 0)
+            I3 = B4%(P, LIVE_HR, 0)
         Else
-            I2 = B4%(P, 0, B1!(P) + 1)
-            I3 = B4%(P, 3, B1!(P) + 1)
+            I2 = B4%(P, LIVE_BAvg, B1!(P) + 1)
+            I3 = B4%(P, LIVE_HR, B1!(P) + 1)
         End If
 
         If Not (baseRunners <> 2 And baseRunners <> 6) Then
@@ -8714,7 +8715,7 @@ Sub SOURCE ()
         If Not (baseRunners = 0 Or nbrOuts(0) > 0 Or baseRunners = 7 Or baseRunners = 6 Or baseRunners = 3 Or baseRunners = 5 Or nbrStrikes = 2 Or P = 0 And INNING% > 7) Then
 
             If B7%(P, B1!(P)) = 1 And baseRunners = 1 And nbrOuts(0) < 2 Or B7%(P, B1!(P)) = 1 And baseRunners = 2 And nbrOuts(0) = 0 Or B7%(P, B1!(P)) = 1 And baseRunners = 4 And nbrOuts(0) = 0 Then 18969
-            If B1!(P) > 2 And B1!(P) < 6 Or B4%(P, 0, B1!(P)) > 290 And B7%(P, B1!(P)) <> 1 Or B7%(P, B1!(P)) <> 1 And B4%(P, 3, B1!(P)) > 70 Then 18968
+            If B1!(P) > 2 And B1!(P) < 6 Or B4%(P, LIVE_BAvg, B1!(P)) > 290 And B7%(P, B1!(P)) <> 1 Or B7%(P, B1!(P)) <> 1 And B4%(P, LIVE_HR, B1!(P)) > 70 Then 18968
             If INNING% > 7 And A1 = -1 And nbrOuts(0) = 0 And baseRunners = 1 Then 18969
 
         End If
@@ -8727,7 +8728,7 @@ Sub SOURCE ()
 
     Call Rolld100(RN0)
 
-    If nbrOuts(0) = 2 Or B4%(P, 4, B1!(P)) > 100 Or baseRunners = 0 Or baseRunners = 7 Or baseRunners = 6 Or baseRunners = 3 Or baseRunners = 2 Or A1 < -3 Or RN0 > 20 Then
+    If nbrOuts(0) = 2 Or B4%(P, LIVE_K, B1!(P)) > 100 Or baseRunners = 0 Or baseRunners = 7 Or baseRunners = 6 Or baseRunners = 3 Or baseRunners = 2 Or A1 < -3 Or RN0 > 20 Then
         GoTo 15064
     Else
         P2 = 2

--- a/src/SOURCE.bi
+++ b/src/SOURCE.bi
@@ -1,3 +1,5 @@
+'$INCLUDE: 'Consts.bi'
+
 'Define all routines for this module
 DECLARE SUB SOURCE ()
 

--- a/src/Variables.bi
+++ b/src/Variables.bi
@@ -24,7 +24,7 @@ Dim losePitcher$(MAX_SCHED_STATS), winPitcher$(MAX_SCHED_STATS)
 
 Dim statB(0 To 22), statB0(0 To 22, 0 To 41)
 Dim statP(0 To 21), statP0(0 To 21, 0 To 41)
-Dim Shared gameD0(0), gameD1(1)
+Dim Shared gameD0(1), gameD1(1)
 
 Dim statS0(0 To 22, 0 To 6)
 


### PR DESCRIPTION
I'm seeing fewer HR's now, hopefully this is closer to normal.  I see my editor removed trailing spaces from several lines, making this PR look like more than it really is.  All I did was add a GOTO to avoid the automatic fallthrough to a HR.  I _think_ that's what was needed.